### PR TITLE
Add strict mode to Mirte

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -96,10 +96,11 @@ class Manager(Module):
 
     class GoCa_Plan(object):
         """ A partial plan for a get_or_create_a call """
-        def __init__(self, man, targets, insts=None,
+        def __init__(self, man, targets, parent, insts=None,
                 insts_implementing=None):
             self.man = man
             self.targets = targets
+            self.parent = parent
             self.insts = dict() if insts is None else insts
             self.insts_implementing = (dict() if insts_implementing
                     is None else insts_implementing)
@@ -160,7 +161,7 @@ class Manager(Module):
             choices_t = choices.items()
             for choice in product(*[xrange(len(v))
                     for k, v in choices_t]):
-                plan2 = Manager.GoCa_Plan(self.man, dict(),
+                plan2 = Manager.GoCa_Plan(self.man, dict(), self.parent,
                         dict(self.insts),
                         dict(self.insts_implementing))
                 tmp = [(choices_t[n][0], choices_t[n][1][m])
@@ -189,10 +190,10 @@ class Manager(Module):
         """ Gets or creates an instance of type <_type> """
         return self.insts[self._get_or_create_a(_type)].object
 
-    def _get_or_create_a(self, _type):
+    def _get_or_create_a(self, _type, _parent=None):
         """ Gets or creates an instance of type <_type> """
-        self.l.debug("get_or_create_a: %s" % _type)
-        stack = [Manager.GoCa_Plan(self, {_type:()})]
+        self.l.debug("get_or_create_a for %s: %s" % (_parent, _type))
+        stack = [Manager.GoCa_Plan(self, {_type:()}, _parent)]
         while stack:
             p = stack.pop()
             if p.finished:
@@ -251,7 +252,7 @@ class Manager(Module):
         for k, v in md.deps.iteritems():
             if not k in settings:
                 settings[k] = self._get_or_create_a(
-                        v.type)
+                        v.type, moduleName)
             if not settings[k] in self.insts:
                 raise ValueError, "No such instance %s" \
                         % settings[k]

--- a/src/core.py
+++ b/src/core.py
@@ -33,6 +33,7 @@ class Manager(Module):
         if logger is None:
             logger = logging.getLogger(object.__repr__(self))
         super(Manager, self).__init__({}, logger)
+        self.strict = False
         self.running = False
         self.running_event = threading.Event()
         self.modules = dict()
@@ -58,6 +59,12 @@ class Manager(Module):
         self.sleep_event = KeyboardInterruptableEvent()
         # set of paths of the mirteFiles that already have been loaded
         self.loaded_mirteFiles = set([])
+
+    def set_strict(self, strict):
+        """ Change the strictness of this Manager. If strictness is enabled,
+            a Mirtefile referencing a non-existing object will cause an
+            exception to be thrown, instead of creating a new object. """
+        self.strict = strict
 
     def _get_all(self, _type):
         """ Gets all instances implementing type <_type> """

--- a/src/core.py
+++ b/src/core.py
@@ -9,6 +9,9 @@ from sarah.runtime import get_by_path
 from sarah._itertools import pick
 from sarah._threading import KeyboardInterruptableEvent
 
+class StrictModeError(Exception):
+    pass
+
 class Module(object):
     def __init__(self, settings, logger):
         for k, v in settings.items():
@@ -169,6 +172,8 @@ class Manager(Module):
                 for target, inst_or_mod in tmp:
                     if inst_or_mod[0]:
                         name = inst_or_mod[1]
+                    elif self.man.strict:
+                        raise StrictModeError, "Trying to create %s, but not creating dependency instance of %s in strict mode" % (self.parent, inst_or_mod[1])
                     else:
                         name = plan2.plan_a(
                                 inst_or_mod[1])

--- a/src/main.py
+++ b/src/main.py
@@ -14,8 +14,15 @@ def parse_cmdLine_instructions(args):
         put settings. """
     instructions = dict()
     rargs = list()
+    strict = None
     for arg in args:
-        if arg[:2] == '--':
+        # Specialcase --mirte-{strict,lenient}, as it has to be known before
+        # loading of mirte-files starts
+        if arg == '--mirte-strict':
+            strict = True
+        elif arg == '--mirte-lenient':
+            strict = False
+        elif arg[:2] == '--':
             tmp = arg[2:]
             bits = tmp.split('=', 1)
             if len(bits) == 1:
@@ -23,7 +30,7 @@ def parse_cmdLine_instructions(args):
             instructions[bits[0]] = bits[1]
         else:
             rargs.append(arg)
-    return instructions, rargs
+    return instructions, rargs, strict
 
 def execute_cmdLine_instructions(instructions, m, l):
     """ Applies the instructions given via
@@ -78,8 +85,10 @@ def main():
     sarah.coloredLogging.basicConfig(level=logging.DEBUG,
                 formatter=MirteFormatter())
     l = logging.getLogger('mirte')
-    instructions, args = parse_cmdLine_instructions(sys.argv[1:])
+    instructions, args, strict = parse_cmdLine_instructions(sys.argv[1:])
     m = Manager(l)
+    if not strict is None:
+        m.set_strict(strict)
     load_mirteFile(args[0] if args else 'default', m, logger=l)
     execute_cmdLine_instructions(instructions, m, l)
     m.run()


### PR DESCRIPTION
This patch adds strict mode to Mirte (disabled by default). When enabled, either by calling `manager.set_strict(True)` or adding `--mirte-strict` to the command-line parameters to `mirte`, the Mirte Manager will not allow silent creation of modules, and will instead throw an exception describing which module had which silent dependency.

I propose that this mode of operation at some point becomes the default (by setting self.strict to True in the Manager constructor). For this, Mirte files may need some adjustment to explicitly name every dependency object. The advantage is that there will be no more bugs in applications because of the wrong object being silently created when the right object is only being created later on, but not used. For example, using this patch and some additions to the Marietje mirtefile, my Marietje installation now uses the right queues in the Orchestrator and the Desk.
